### PR TITLE
Adding examples to datastore command group

### DIFF
--- a/src/vmware/azext_vmware/_help.py
+++ b/src/vmware/azext_vmware/_help.py
@@ -160,19 +160,35 @@ helps['vmware location checktrialavailability'] = """
 helps['vmware datastore create'] = """
     type: command
     short-summary: Create a datastore in a private cloud cluster.
+    examples:
+    - name: Create a new Microsoft.StoragePool provided disk pool based iSCSI datastore.
+      text: az vmware datastore create --name iSCSIDatastore1 --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud --endpoints 10.10.0.1:3260 --lun-name lun0
+    - name: Create a new Microsoft.StoragePool provided disk pool based iSCSI datastore with multiple endpoints.
+      text: az vmware datastore create --name iSCSIDatastore1 --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud --endpoints 10.10.0.1:3260 10.10.0.2:3260 --lun-name lun0
+    - name: Create a new Microsoft.NetApp provided NetApp volume based NFSv3 datastore.
+      text: az vmware datastore create --name ANFDatastore1 --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud --nfs-file-path ANFVol1FilePath --nfs-provider-ip 10.10.0.1
 """
 
 helps['vmware datastore show'] = """
     type: command
     short-summary: Show details of a datastore in a private cloud cluster.
+    examples:
+    - name: Show the details of an iSCSI or NFS based datastore.
+      text: az vmware datastore show --name MyCloudSANDatastore1 --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud
 """
 
 helps['vmware datastore list'] = """
     type: command
     short-summary: List datastores in a private cloud cluster.
+    examples:
+    - name: List all iSCSI or NFS based datastores under Cluster-1.
+      text: az vmware datastore list --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud
 """
 
 helps['vmware datastore delete'] = """
     type: command
     short-summary: Delete a datastore in a private cloud cluster.
+    examples:
+    - name: Delete an iSCSI or NFS based datastore.
+      text: az vmware datastore delete --name MyCloudSANDatastore1 --resource-group MyResourceGroup --cluster Cluster-1 --private-cloud MyPrivateCloud
 """


### PR DESCRIPTION
Example CLI usage for each of `az vmware datastore` commands will look like this upon using `-h` flag -

```
(env3) PS E:\AzureCLIDevEnv> az vmware datastore create -h
This command is from the following extension: vmware

Command
    az vmware datastore create : Create a datastore in a private cloud cluster.

Arguments
    --cluster           [Required] : The name of the cluster.
    --name -n           [Required] : The name of the datastore.
    --private-cloud -c  [Required] : Name of the private cloud.
    --resource-group -g [Required] : Name of resource group. You can configure the default group
                                     using `az configure --defaults group=<name>`.
    --endpoints                    : ISCSI provider target IP address list.
    --lun-name                     : Name of the LUN to be used.
    --nfs-file-path                : File path through which the NFS volume is exposed by the   
                                     provider.
    --nfs-provider-ip              : IP address of the NFS provider.

Global Arguments
    --debug                        : Increase logging verbosity to show all debug logs.
    --help -h                      : Show this help message and exit.
    --only-show-errors             : Only show errors, suppressing warnings.
    --output -o                    : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                     yaml, yamlc.  Default: json.
    --query                        : JMESPath query string. See http://jmespath.org/ for more
                                     information and examples.
    --subscription                 : Name or ID of subscription. You can configure the default
                                     subscription using `az account set -s NAME_OR_ID`.
    --verbose                      : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Create a new Microsoft.StoragePool provided disk pool based iSCSI datastore.
        az vmware datastore create --name iSCSIDatastore1 --resource-group MyResourceGroup --cluster
        Cluster-1 --private-cloud MyPrivateCloud --endpoints 10.10.0.1:3260 --lun-name lun0

    Create a new Microsoft.StoragePool provided disk pool based iSCSI datastore with multiple
    endpoints.
        az vmware datastore create --name iSCSIDatastore1 --resource-group MyResourceGroup --cluster
        Cluster-1 --private-cloud MyPrivateCloud --endpoints 10.10.0.1:3260 10.10.0.2:3260 --lun-
        name lun0

    Create a new Microsoft.NetApp provided NetApp volume based NFSv3 datastore.
        az vmware datastore create --name ANFDatastore1 --resource-group MyResourceGroup --cluster
        Cluster-1 --private-cloud MyPrivateCloud --nfs-file-path ANFVol1FilePath --nfs-provider-ip
        10.10.0.1

For more specific examples, use: az find "az vmware datastore create"

Please let us know how we are doing: https://aka.ms/azureclihats
(env3) PS E:\AzureCLIDevEnv> az vmware datastore show -h
This command is from the following extension: vmware

Command
    az vmware datastore show : Show details of a datastore in a private cloud cluster.

Arguments
    --cluster            [Required] : The name of the cluster.
    --name -n            [Required] : The name of the datastore.
    --private-cloud -c   [Required] : Name of the private cloud.
    --resource-group -g  [Required] : Name of resource group. You can configure the default group
                                      using `az configure --defaults group=<name>`.

Global Arguments
    --debug                         : Increase logging verbosity to show all debug logs.
    --help -h                       : Show this help message and exit.
    --only-show-errors              : Only show errors, suppressing warnings.
    --output -o                     : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                      yaml, yamlc.  Default: json.
    --query                         : JMESPath query string. See http://jmespath.org/ for more
                                      information and examples.
    --query-examples [Experimental] : Recommend JMESPath string for you. You can copy one
                                      of the query and paste it after --query parameter within
                                      double quotation marks to see the results. You can add one or
                                      more positional keywords so that we can give suggestions based
                                      on these key words.
        This parameter is experimental and under development. Reference and support levels:
        https://aka.ms/CLI_refstatus
    --subscription                  : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
    --verbose                       : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Show the details of an iSCSI or NFS based datastore.
        az vmware datastore show --name MyCloudSANDatastore1 --resource-group MyResourceGroup
        --cluster Cluster-1 --private-cloud MyPrivateCloud

For more specific examples, use: az find "az vmware datastore show"
(env3) PS E:\AzureCLIDevEnv> az vmware datastore list -h
This command is from the following extension: vmware

Command
    az vmware datastore list : List datastores in a private cloud cluster.

Arguments
    --cluster            [Required] : The name of the cluster.
    --private-cloud -c   [Required] : Name of the private cloud.
    --resource-group -g  [Required] : Name of resource group. You can configure the default group
                                      using `az configure --defaults group=<name>`.

Global Arguments
    --debug                         : Increase logging verbosity to show all debug logs.
    --help -h                       : Show this help message and exit.
    --only-show-errors              : Only show errors, suppressing warnings.
    --output -o                     : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                      yaml, yamlc.  Default: json.
    --query                         : JMESPath query string. See http://jmespath.org/ for more
                                      information and examples.
    --query-examples [Experimental] : Recommend JMESPath string for you. You can copy one
                                      of the query and paste it after --query parameter within
                                      double quotation marks to see the results. You can add one or
                                      more positional keywords so that we can give suggestions based
                                      on these key words.
        This parameter is experimental and under development. Reference and support levels:
        https://aka.ms/CLI_refstatus
    --subscription                  : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
    --verbose                       : Increase logging verbosity. Use --debug for full debug logs.

Examples
        az vmware datastore list --resource-group MyResourceGroup --cluster Cluster-1 --private-
        cloud MyPrivateCloud

For more specific examples, use: az find "az vmware datastore list"

Please let us know how we are doing: https://aka.ms/azureclihats
(env3) PS E:\AzureCLIDevEnv>
(env3) PS E:\AzureCLIDevEnv>
(env3) PS E:\AzureCLIDevEnv> az vmware datastore delete -h
This command is from the following extension: vmware

Command
    az vmware datastore delete : Delete a datastore in a private cloud cluster.

Arguments
    --cluster           [Required] : The name of the cluster.
    --name -n           [Required] : The name of the datastore.
    --private-cloud -c  [Required] : Name of the private cloud.
    --resource-group -g [Required] : Name of resource group. You can configure the default group
                                     using `az configure --defaults group=<name>`.

Global Arguments
    --debug                        : Increase logging verbosity to show all debug logs.
    --help -h                      : Show this help message and exit.
    --only-show-errors             : Only show errors, suppressing warnings.
    --output -o                    : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                     yaml, yamlc.  Default: json.
    --query                        : JMESPath query string. See http://jmespath.org/ for more
                                     information and examples.
    --subscription                 : Name or ID of subscription. You can configure the default
                                     subscription using `az account set -s NAME_OR_ID`.
    --verbose                      : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Delete an iSCSI or NFS based datastore.
        az vmware datastore delete --name MyCloudSANDatastore1 --resource-group MyResourceGroup
        --cluster Cluster-1 --private-cloud MyPrivateCloud

For more specific examples, use: az find "az vmware datastore delete"

Please let us know how we are doing: https://aka.ms/azureclihats
(env3) PS E:\AzureCLIDevEnv>
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).
